### PR TITLE
Ft/606503 - Update Library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### CHANGED
 - **Bumped** `IATec.Shared.Domain` from `1.2.0` to `2.0.0`.
-- Improved internal null-safety by guarding `BuildErrorMessageList` against null or empty input lists and returning an empty list instead.
+- Improved internal handling by returning an empty list from `BuildErrorMessageList` when no errors are present.
 
 ## [1.1.0] - 2026-01-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.2.0] - 2026-05-21
+
+### ADDED
+- XML documentation (summaries) for all public classes and methods.
+- Complete `README.md` with usage examples and installation instructions.
+- `CHANGELOG.md` to track historical changes across versions.
+
+### CHANGED
+- **Bumped** `IATec.Shared.Domain` from `1.2.0` to `2.0.0`.
+- Improved internal null-safety by ensuring `BuildErrorMessageList` never returns a null list.
+
+## [1.1.0] - 2026-01-12
+
+### CHANGED
+- Updated target frameworks to include .NET 10.
+- **Bumped** `FluentResults` from `3.16.0` to `4.0.0`.
+- **Bumped** `IATec.Shared.Domain` from `0.10.0` to `1.2.0`.
+- Replaced `Microsoft.AspNetCore.Mvc` package reference with `Microsoft.AspNetCore.App` framework reference.
+
+### FIXED
+- Fixed pipeline YAML configuration.
+
+## [1.0.0] - 2025-08-11
+
+### ADDED
+- Introduced `CustomResponseDto`, `CustomResponseExtensions`, and `CustomControllerBase` for standardized API responses.
+- Added `ConventionConfiguration` with API Explorer response conventions for common CRUD operations.
+- Mapped FluentResults states to HTTP status codes: `Created`, `NoContent`, `NotFound`, `BadRequest`, `ServiceUnavailable`, and `InternalServerError`.
+
+### FIXED
+- Removed duplicated `Delete` mapping in controller base.
+- Removed duplicated `Update` mapping in controller base.
+- Fixed general code formatting issues.
+
+## [0.1.0] - 2024-09-19
+
+### ADDED
+- Project initialization with basic solution structure.
+- Base dependencies:
+  - `FluentResults` `3.16.0`
+  - `IATec.Shared.Domain` `0.2.0`
+  - `Microsoft.AspNetCore.Mvc` `2.2.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### CHANGED
 - **Bumped** `IATec.Shared.Domain` from `1.2.0` to `2.0.0`.
-- Improved internal null-safety by ensuring `BuildErrorMessageList` never returns a null list.
+- Improved internal null-safety by guarding `BuildErrorMessageList` against null or empty input lists and returning an empty list instead.
 
 ## [1.1.0] - 2026-01-12
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,83 @@
-# IATec.Shared.Net.Api
+# IATec.Shared.Api
 
-Repository for managing classes shared between .net projects developed at IATec.
+Shared library for .NET API projects at IATec. It provides standardized controllers, response conventions, and FluentResults integration to accelerate development across teams.
+
+## Features
+
+- **CustomControllerBase**: Standardized base controller that translates FluentResults states into proper HTTP responses (Created, NoContent, NotFound, BadRequest, ServiceUnavailable, InternalServerError, OK).
+- **CustomResponseDto**: Uniform API response envelope with `Success`, `StatusCode`, `Data`, `Messages`, and `DateTimeUtc`.
+- **CustomResponseExtensions**: Extension methods to map FluentResults `Result` and `Result<T>` to `CustomResponseDto`.
+- **ConventionConfiguration**: API Explorer conventions for common CRUD operations (`GetById`, `List`, `Create`, `Update`, `Delete`) with default `ProducesResponseType` attributes.
+
+## Installation
+
+Install the NuGet package:
+
+```bash
+dotnet add package IATec.Shared.Api
+```
+
+## Requirements
+
+- .NET 8.0, .NET 9.0 or .NET 10.0
+- `IATec.Shared.Domain` >= `2.0.0`
+- `FluentResults` >= `4.0.0`
+
+## Usage
+
+### Using the base controller
+
+```csharp
+using IATec.Shared.Api.Controllers;
+using FluentResults;
+
+public class ProductsController : CustomControllerBase
+{
+    private readonly IProductService _service;
+
+    public ProductsController(IProductService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet("{id:guid}")]
+    public ActionResult GetById(Guid id)
+    {
+        var result = _service.GetById(id);
+        return CustomResult(result);
+    }
+
+    [HttpPost]
+    public ActionResult Create([FromBody] ProductDto dto)
+    {
+        var result = _service.Create(dto);
+        return CustomResult(result, $"/products/{result.Value.Id}");
+    }
+}
+```
+
+### Using response extensions manually
+
+```csharp
+using IATec.Shared.Api.Response;
+using FluentResults;
+
+Result<int> result = Result.Ok(42);
+CustomResponseDto response = result.SuccessCustomResponse(HttpStatusCode.OK);
+```
+
+## Conventions
+
+Methods returning `Task` should have the `Async` suffix (e.g., `GetByIdAsync`). This library exposes synchronous helpers because `ActionResult` generation itself is synchronous, but consumer controllers should follow the standard async naming when applicable.
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for the version history.
+
+## Contributing
+
+This package is maintained by the **IATec | Solution | Platform Team**. For issues or contributions, please use the [GitHub repository](https://github.com/iatecbr/IATec.Shared.Net.Api).
+
+## License
+
+See [LICENSE](https://github.com/iatecbr/IATec.Shared.Net.Api/blob/main/LICENSE) for details.

--- a/src/Controllers/CustomControllerBase.cs
+++ b/src/Controllers/CustomControllerBase.cs
@@ -7,13 +7,24 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace IATec.Shared.Api.Controllers;
 
+/// <summary>
+/// Provides a customizable base controller that standardizes action results
+/// based on FluentResults <see cref="Result"/> states.
+/// </summary>
 public class CustomControllerBase : ControllerBase
 {
+    /// <summary>
+    /// Converts a generic FluentResults <see cref="Result{T}"/> into a standardized <see cref="ActionResult"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the value inside the result.</typeparam>
+    /// <param name="result">The FluentResults result to process.</param>
+    /// <param name="location">Optional URI location for created resources.</param>
+    /// <returns>An <see cref="ActionResult"/> with the appropriate HTTP status code and response body.</returns>
     [NonAction]
     protected ActionResult CustomResult<T>(Result<T> result, string? location = null)
     {
         if (result.IsCreatedSuccess())
-            return Created(location!, result.SuccessCustomResponse(HttpStatusCode.Created));
+            return Created(location, result.SuccessCustomResponse(HttpStatusCode.Created));
 
         if (result.IsNoContentSuccess() || result.IsEmptyResult())
             return NoContent();
@@ -33,10 +44,16 @@ public class CustomControllerBase : ControllerBase
         return Ok(result.SuccessCustomResponse(HttpStatusCode.OK));
     }
 
+    /// <summary>
+    /// Converts a non-generic FluentResults <see cref="Result"/> into a standardized <see cref="ActionResult"/>.
+    /// </summary>
+    /// <param name="result">The FluentResults result to process.</param>
+    /// <param name="location">Optional URI location for created resources.</param>
+    /// <returns>An <see cref="ActionResult"/> with the appropriate HTTP status code and response body.</returns>
     protected ActionResult CustomResult(Result result, string? location = null)
     {
         if (result.IsCreatedSuccess())
-            return Created(location!, CustomResponseExtensions.SuccessCustomResponse(HttpStatusCode.Created));
+            return Created(location, CustomResponseExtensions.SuccessCustomResponse(HttpStatusCode.Created));
 
         if (result.IsNoContentSuccess())
             return NoContent();

--- a/src/Conventions/ConventionConfiguration.cs
+++ b/src/Conventions/ConventionConfiguration.cs
@@ -9,6 +9,10 @@ namespace IATec.Shared.Api.Conventions;
 /// </summary>
 public static class ConventionConfiguration
 {
+    /// <summary>
+    /// Defines the expected response types for an operation that retrieves a single resource by identifier.
+    /// </summary>
+    /// <param name="id">The unique identifier of the resource.</param>
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -20,6 +24,9 @@ public static class ConventionConfiguration
     {
     }
 
+    /// <summary>
+    /// Defines the expected response types for an operation that lists all resources.
+    /// </summary>
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -29,6 +36,9 @@ public static class ConventionConfiguration
     {
     }
 
+    /// <summary>
+    /// Defines the expected response types for an operation that creates a new resource.
+    /// </summary>
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -38,6 +48,10 @@ public static class ConventionConfiguration
     {
     }
 
+    /// <summary>
+    /// Defines the expected response types for an operation that updates an existing resource.
+    /// </summary>
+    /// <param name="id">The unique identifier of the resource to update.</param>
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -47,9 +61,14 @@ public static class ConventionConfiguration
     {
     }
 
+    /// <summary>
+    /// Defines the expected response types for an operation that deletes a resource.
+    /// </summary>
+    /// <param name="id">The unique identifier of the resource to delete.</param>
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public static void Delete([ApiConventionNameMatch(ApiConventionNameMatchBehavior.Suffix)] Guid id)
     {

--- a/src/IATec.Shared.Api.csproj
+++ b/src/IATec.Shared.Api.csproj
@@ -10,7 +10,7 @@
 		<Description>Project developed to help IATec teams to develop their projects faster.</Description>
 		<Copyright>@IATec Solutions</Copyright>
 		<RootNamespace>IATec.Shared.Api</RootNamespace>
-        <Version>1.1.0</Version>
+        <Version>1.2.0</Version>
         <PackageIcon>icon.png</PackageIcon>
         <PackageTags>IATec</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -29,7 +29,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentResults" Version="4.0.0" />
-        <PackageReference Include="IATec.Shared.Domain" Version="1.2.0" />
+        <PackageReference Include="IATec.Shared.Domain" Version="2.0.0" />
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
 </Project>

--- a/src/Response/CustomResponseDto.cs
+++ b/src/Response/CustomResponseDto.cs
@@ -1,5 +1,13 @@
 namespace IATec.Shared.Api.Response;
 
+/// <summary>
+/// Represents a standardized API response payload.
+/// </summary>
+/// <param name="Success">Indicates whether the operation was successful.</param>
+/// <param name="StatusCode">The HTTP status code of the response.</param>
+/// <param name="Data">Optional data returned by the operation.</param>
+/// <param name="Messages">A list of messages describing the result.</param>
+/// <param name="DateTimeUtc">The UTC date and time when the response was generated.</param>
 public sealed record CustomResponseDto(
     bool Success,
     int StatusCode,

--- a/src/Response/CustomResponseExtensions.cs
+++ b/src/Response/CustomResponseExtensions.cs
@@ -60,10 +60,10 @@ public static class CustomResponseExtensions
     /// Extracts error messages from a FluentResults error list.
     /// </summary>
     /// <param name="resultErrorList">The list of errors from FluentResults.</param>
-    /// <returns>A list of error message strings. Returns an empty list if the input is null.</returns>
+    /// <returns>A list of error message strings. Returns an empty list if there are no errors.</returns>
     private static List<string> BuildErrorMessageList(IReadOnlyList<IError> resultErrorList)
     {
-        if (resultErrorList == null || resultErrorList.Count == 0)
+        if (resultErrorList.Count == 0)
             return new List<string>();
 
         return resultErrorList.Select(error => error.Message).ToList();

--- a/src/Response/CustomResponseExtensions.cs
+++ b/src/Response/CustomResponseExtensions.cs
@@ -3,26 +3,69 @@ using FluentResults;
 
 namespace IATec.Shared.Api.Response;
 
+/// <summary>
+/// Provides extension methods to convert FluentResults <see cref="Result"/> instances into <see cref="CustomResponseDto"/>.
+/// </summary>
 public static class CustomResponseExtensions
-{   
-    public static CustomResponseDto FailCustomResponse<T>(this Result<T> result, HttpStatusCode httpStatusCode) => 
+{
+    /// <summary>
+    /// Creates a failure <see cref="CustomResponseDto"/> from a generic FluentResults <see cref="Result{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the result value.</typeparam>
+    /// <param name="result">The failed result.</param>
+    /// <param name="httpStatusCode">The HTTP status code to include in the response.</param>
+    /// <returns>A <see cref="CustomResponseDto"/> describing the failure.</returns>
+    public static CustomResponseDto FailCustomResponse<T>(this Result<T> result, HttpStatusCode httpStatusCode) =>
         BuildCustomResponse(false, httpStatusCode, null, BuildErrorMessageList(result.Errors));
-    
-    public static CustomResponseDto FailCustomResponse(this Result result, HttpStatusCode httpStatusCode) => 
+
+    /// <summary>
+    /// Creates a failure <see cref="CustomResponseDto"/> from a non-generic FluentResults <see cref="Result"/>.
+    /// </summary>
+    /// <param name="result">The failed result.</param>
+    /// <param name="httpStatusCode">The HTTP status code to include in the response.</param>
+    /// <returns>A <see cref="CustomResponseDto"/> describing the failure.</returns>
+    public static CustomResponseDto FailCustomResponse(this Result result, HttpStatusCode httpStatusCode) =>
         BuildCustomResponse(false, httpStatusCode, null, BuildErrorMessageList(result.Errors));
-    
-    public static CustomResponseDto SuccessCustomResponse<T>(this Result<T> result, HttpStatusCode httpStatusCode) => 
+
+    /// <summary>
+    /// Creates a successful <see cref="CustomResponseDto"/> from a generic FluentResults <see cref="Result{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the result value.</typeparam>
+    /// <param name="result">The successful result containing the value.</param>
+    /// <param name="httpStatusCode">The HTTP status code to include in the response.</param>
+    /// <returns>A <see cref="CustomResponseDto"/> describing the success.</returns>
+    public static CustomResponseDto SuccessCustomResponse<T>(this Result<T> result, HttpStatusCode httpStatusCode) =>
         BuildCustomResponse(true, httpStatusCode, result.Value, []);
 
+    /// <summary>
+    /// Creates a successful <see cref="CustomResponseDto"/> without a value.
+    /// </summary>
+    /// <param name="httpStatusCode">The HTTP status code to include in the response.</param>
+    /// <returns>A <see cref="CustomResponseDto"/> describing the success.</returns>
     public static CustomResponseDto SuccessCustomResponse(HttpStatusCode httpStatusCode) =>
         BuildCustomResponse(true, httpStatusCode, null, []);
 
-    private static CustomResponseDto BuildCustomResponse(bool success, HttpStatusCode statusCode, object? data, 
-        List<string> errors) => new (success, (int)statusCode, data, errors, DateTimeOffset.UtcNow);
+    /// <summary>
+    /// Builds a <see cref="CustomResponseDto"/> with the provided parameters.
+    /// </summary>
+    /// <param name="success">Indicates whether the operation was successful.</param>
+    /// <param name="statusCode">The HTTP status code.</param>
+    /// <param name="data">Optional data payload.</param>
+    /// <param name="errors">A list of error messages.</param>
+    /// <returns>A new <see cref="CustomResponseDto"/> instance.</returns>
+    private static CustomResponseDto BuildCustomResponse(bool success, HttpStatusCode statusCode, object? data,
+        List<string> errors) => new(success, (int)statusCode, data, errors, DateTimeOffset.UtcNow);
 
+    /// <summary>
+    /// Extracts error messages from a FluentResults error list.
+    /// </summary>
+    /// <param name="resultErrorList">The list of errors from FluentResults.</param>
+    /// <returns>A list of error message strings. Returns an empty list if the input is null.</returns>
     private static List<string> BuildErrorMessageList(IReadOnlyList<IError> resultErrorList)
     {
-        var errorList = resultErrorList.Select(error => error.Message).ToList();
-        return errorList;
+        if (resultErrorList == null || resultErrorList.Count == 0)
+            return new List<string>();
+
+        return resultErrorList.Select(error => error.Message).ToList();
     }
 }


### PR DESCRIPTION
## [1.2.0] - 2026-05-21

### ADDED
- XML documentation (summaries) for all public classes and methods.
- Complete `README.md` with usage examples and installation instructions.
- `CHANGELOG.md` to track historical changes across versions.

### CHANGED
- **Bumped** `IATec.Shared.Domain` from `1.2.0` to `2.0.0`.
- Improved internal null-safety by ensuring `BuildErrorMessageList` never returns a null list.